### PR TITLE
sns-teams-relay v2.0.0

### DIFF
--- a/sns-teams-relay/README.md
+++ b/sns-teams-relay/README.md
@@ -19,9 +19,19 @@ See [tf-module-sns-teams-relay](https://github.com/CU-CommunityApps/tf-module-sn
 - [template.yaml](template.yaml) -- CloudFormation template
 - [example-notifications](example-notifications/) -- Examples of SNS and message content
 
+## Change Log
+
+### v2.0.0
+- apply some Python style fixes
+- add support for two different webhook URLs; one handles regular notifications, one handles more critical notifications
+- add support for contextual colors, depending on notification type
+
+### v1.0.0
+- initial release
+
 ## Prerequisites for `deploy.sh` and `invoke.sh` script
 
-- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) and an active session with priviledges to create/manage CloudFormation stacks and store data in an S3 bucket
+- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) and an active session with privileges to create/manage CloudFormation stacks and store data in an S3 bucket
 - `cfn-flip`: https://github.com/awslabs/aws-cfn-template-flip
 - `jq`: https://stedolan.github.io/jq/
 - `cfn-lint`: https://github.com/aws-cloudformation/cfn-python-lint
@@ -29,8 +39,9 @@ See [tf-module-sns-teams-relay](https://github.com/CU-CommunityApps/tf-module-sn
 ## Deploy
 
 1. Customize the following variables in [deploy.sh](deploy.sh):
-  - `WEBHOOK_URL`: The URL for your Teams webhook
-  - `S3_BUCKET`: Any S3 bucket that you have write priviledges to. Used as temporary storage during the `aws cloudformation package` and `aws cloudformation deploy` processes.
+  - `WEBHOOK_URL_NORMAL`: The URL for your Teams webhook for success, warning, info messages
+  - `WEBHOOK_URL_ALERT`: The URL for your Teams webhook for failure of any type. If you only have a single webhook, set this to be the same as `WEBHOOK_URL_NORMAL` 
+  - `S3_BUCKET`: Any S3 bucket that you have write privileges to. Used as temporary storage during the `aws cloudformation package` and `aws cloudformation deploy` processes.
 2. Run `./deploy.sh`
 3. To test the deployment, run `./invoke.sh` to send a test message to the Lambda function. This should trigger a new message to the target Teams channel (via the webhook).
 

--- a/sns-teams-relay/deploy.sh
+++ b/sns-teams-relay/deploy.sh
@@ -16,7 +16,8 @@
 # Bucket to use for temporary location for Lambda/CloudFormation deploy package
 S3_BUCKET=CHANGE_ME
 # Your Teams webhook URL
-WEBHOOK_URL=https://cornellprod.webhook.office.com/CHANGE_ME
+WEBHOOK_URL_NORMAL=https://cornellprod.webhook.office.com/CHANGE_ME
+WEBHOOK_URL_ALERT=https://cornellprod.webhook.office.com/CHANGE_ME
 ENV=${ENV:-dev}
 ###############################################################################
 
@@ -29,13 +30,13 @@ STACK_NAME=$(eval "echo $STACK_NAME")
 
 echo "########## PROPERTIES ##########"
 echo "Template: $TARGET_TEMPLATE"
-echo "Depoying/Updating stack: $STACK_NAME"
+echo "Deploying/Updating stack: $STACK_NAME"
 echo "Deploying template version: $TEMPLATE_VERSION"
 
 echo "########## LINT ##########"
 cfn-lint $TARGET_TEMPLATE
 
-echo "########## VALDIATE ##########"
+echo "########## VALIDATE ##########"
 set -e # Stop the script if it doesn't validate.
 aws cloudformation validate-template --template-body file://$TARGET_TEMPLATE
 
@@ -59,7 +60,8 @@ aws cloudformation deploy \
   --parameter-overrides \
       VersionParam="$TEMPLATE_VERSION" \
       EnvironmentParam="$ENV" \
-      TeamsWebhookURLParam="$WEBHOOK_URL"
+      TeamsWebhookNormalURLParam="$WEBHOOK_URL_NORMAL" \
+      TeamsWebhookAlertURLParam="$WEBHOOK_URL_ALERT"
 
 aws cloudformation update-termination-protection \
   --enable-termination-protection \

--- a/sns-teams-relay/lambda/sns-teams-relay.py
+++ b/sns-teams-relay/lambda/sns-teams-relay.py
@@ -1,5 +1,5 @@
 """
-Relay incoming SNS messages to a Microsoft Teams webhook
+Relay incoming SNS messages to Microsoft Teams webhooks
 """
 import os
 import urllib3
@@ -9,164 +9,206 @@ import logging
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
-http = urllib3.PoolManager() 
-url = os.environ['WEBHOOK_URL']
+http = urllib3.PoolManager()
+webhook_url_normal = os.environ['WEBHOOK_URL_NORMAL']
+webhook_url_alert = os.environ['WEBHOOK_URL_ALERT']
 
+# Contextual colors
 info_color = '1919ff'
-# Contextual colors to be implemented 
-# failure_color = 'b20000'
-# success_color = '007300'
-# warning_color = 'ffcc00',
+failure_color = 'b20000'
+success_color = '007300'
+warning_color = 'ffcc00'
 default_color = info_color
 
-def handler(event, context):
+# Map STATES/STATUS/CODES to colors and urls based
 
-  logger.debug("Received event: " + json.dumps(event, indent=2))
-  message = event['Records'][0]['Sns']['Message']
-  
-  try:
-    data = json.loads(message)
-  except ValueError:
-    # not valid JSON
-    data = {}
-  
-  msg_type = data.get('detailType', None)
-  is_approval = "approval" in  data
-  
-  if is_approval:
-    msg = handle_codepipeline_approval(data, event)
-  elif msg_type == "CodeBuild Build State Change":
-    msg = handle_codebuild_state_change(data)
-  elif msg_type == "CodeBuild Build Phase Change":
-    msg = handle_codebuild_phase_change(data)
-  elif msg_type == "CodePipeline Pipeline Execution State Change":
-    msg = handle_codepipeline_state_change(data)
-  elif msg_type == "CodePipeline Action Execution State Change":
-    msg = handle_codepipeline_execution_state_change(data)    
-  else:
-    msg = handle_unknown_event(event, context)
-  
-  encoded_msg = json.dumps(msg).encode('utf-8')
-  logger.info("Sending message:")
-  logger.info(encoded_msg)
-  resp = http.request('POST',url, body=encoded_msg)
-  
-  logger.info("Response:")
-  logger.info({
-      "status_code": resp.status, 
-      "response": resp.data
-  })  
-  return None
+codebuild_build_state_map = {
+    "IN_PROGRESS": {"color": info_color, "url": webhook_url_normal},
+    "SUCCEEDED": {"color": success_color, "url": webhook_url_normal},
+    "FAILED": {"color": failure_color, "url": webhook_url_alert},
+    "STOPPED": {"color": warning_color, "url": webhook_url_normal},
+}
+
+codebuild_build_phase_map = {
+    "TIMED_OUT": {"color": failure_color, "url": webhook_url_alert},
+    "STOPPED": {"color": warning_color, "url": webhook_url_normal},
+    "FAILED": {"color": failure_color, "url": webhook_url_alert},
+    "SUCCEEDED": {"color": success_color, "url": webhook_url_normal},
+    "FAULT": {"color": failure_color, "url": webhook_url_alert},
+    "CLIENT_ERROR": {"color": failure_color, "url": webhook_url_alert},
+}
+
+codepipeline_pipeline_execution_state_map = {
+    "CANCELED": {"color": warning_color, "url": webhook_url_normal},
+    "FAILED": {"color": failure_color, "url": webhook_url_alert},
+    "RESUMED": {"color": info_color, "url": webhook_url_normal},
+    "STARTED": {"color": info_color, "url": webhook_url_normal},
+    "STOPPED": {"color": warning_color, "url": webhook_url_normal},
+    "STOPPING": {"color": warning_color, "url": webhook_url_normal},
+    "SUCCEEDED": {"color": success_color, "url": webhook_url_normal},
+    "SUPERSEDED": {"color": warning_color, "url": webhook_url_normal},
+}
+
+codepipeline_action_execution_state_map = {
+    "ABANDONED": {"color": warning_color, "url": webhook_url_normal},
+    "CANCELED": {"color": warning_color, "url": webhook_url_normal},
+    "FAILED": {"color": failure_color, "url": webhook_url_alert},
+    "STARTED": {"color": info_color, "url": webhook_url_normal},
+    "SUCCEEDED": {"color": success_color, "url": webhook_url_normal},
+}
+
+
+def handler(event, context):
+    logger.debug("Received event: " + json.dumps(event, indent=2))
+    message = event['Records'][0]['Sns']['Message']
+
+    try:
+        data = json.loads(message)
+    except ValueError:
+        # not valid JSON
+        data = {}
+
+    msg_type = data.get('detailType', None)
+    is_approval = "approval" in data
+
+    if is_approval:
+        msg, url = handle_codepipeline_approval(data, event)
+    elif msg_type == "CodeBuild Build State Change":
+        msg, url = handle_codebuild_build_state_change(data)
+    elif msg_type == "CodeBuild Build Phase Change":
+        msg, url = handle_codebuild_build_phase_change(data)
+    elif msg_type == "CodePipeline Pipeline Execution State Change":
+        msg, url = handle_codepipeline_pipeline_execution_state_change(data)
+    elif msg_type == "CodePipeline Action Execution State Change":
+        msg, url = handle_codepipeline_action_execution_state_change(data)
+    else:
+        msg, url = handle_unknown_event(event, context)
+
+    encoded_msg = json.dumps(msg).encode('utf-8')
+    logger.info("Sending message:")
+    logger.info(encoded_msg)
+    resp = http.request('POST', url, body=encoded_msg)
+
+    logger.info("Response:")
+    logger.info({
+        "status_code": resp.status,
+        "response": resp.data
+    })
+    return None
+
 
 def handle_unknown_event(event, context):
-  sns_message = event['Records'][0]['Sns']['Message']
-  sns_subject = event['Records'][0]['Sns']['Subject']
-  summary = f"AWS SNS Teams Relay: {sns_subject}"
-  return {
-    "@type": "MessageCard",
-    "@context": "http://schema.org/extensions",
-    "summary": summary,
-    "themeColor": default_color,
-    "text": f"Message: [{sns_message}]<br />Relayed by {context.invoked_function_arn}",
-    "title": summary,
-    "potentialAction": []        
-  }
-  
+    sns_message = event['Records'][0]['Sns']['Message']
+    sns_subject = event['Records'][0]['Sns']['Subject']
+    summary = f"AWS SNS Teams Relay: {sns_subject}"
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "summary": summary,
+        "themeColor": default_color,
+        "text": f"Message: [{sns_message}]<br />Relayed by {context.invoked_function_arn}",
+        "title": summary,
+        "potentialAction": []
+    }, webhook_url_normal
+
+
 def handle_codepipeline_approval(data, event):
-  summary = event['Records'][0]['Sns'].get('Subject', "SUBJECT_IS_MISSING")
-  account = event['Records'][0]['Sns']['TopicArn'].split(":")[4]
-  approval = data['approval']
-  text = (
-    f"AWS CodePipeline Approval | {data['region']} | {account}<br />"
-    f"Pipeline <b><a href=\"{data['consoleLink']}\">{approval['pipelineName']}</a></b><br />"
-    f"Stage name <b>{approval['stageName']}</b><br />"
-    f"Action name <b>{approval['actionName']}</b><br />"
-    f"<b><a href=\"{approval['approvalReviewLink']}\">Approve or Reject</a></b>"
-  )
-  return {
-      "@type": "MessageCard",
-      "@context": "http://schema.org/extensions",
-      "summary": summary,
-      "themeColor": default_color,
-      "text": text,
-      "title": summary,
-      "potentialAction": []        
-  }
+    summary = event['Records'][0]['Sns'].get('Subject', "SUBJECT_IS_MISSING")
+    account = event['Records'][0]['Sns']['TopicArn'].split(":")[4]
+    approval = data['approval']
+    text = (
+        f"AWS CodePipeline Approval | {data['region']} | {account}<br />"
+        f"Pipeline <b><a href=\"{data['consoleLink']}\">{approval['pipelineName']}</a></b><br />"
+        f"Stage name <b>{approval['stageName']}</b><br />"
+        f"Action name <b>{approval['actionName']}</b><br />"
+        f"<b><a href=\"{approval['approvalReviewLink']}\">Approve or Reject</a></b>"
+    )
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "summary": summary,
+        "themeColor": warning_color,
+        "text": text,
+        "title": summary,
+        "potentialAction": []
+    }, webhook_url_normal
 
 
-def handle_codebuild_state_change(data):
-  detail = data['detail']
-  logs_url = get_logs_url(detail)
-  summary = f"AWS CodeBuild Notification | {data['region']} | {data['account']}"
-  text = (
-    f"Project <b>{detail['project-name']}</b> (<a href=\"{logs_url}\">logs</a>)<br />"
-    f"CodeBuild build state <b>{detail['build-status']}</b><br />"
-  )
-  return {
-      "@type": "MessageCard",
-      "@context": "http://schema.org/extensions",
-      "summary": summary,
-      "themeColor": default_color,
-      "text": text,
-      "title": summary,
-      "potentialAction": []        
-  }
+def handle_codebuild_build_state_change(data):
+    detail = data['detail']
+    logs_url = get_logs_url(detail)
+    summary = f"AWS CodeBuild Notification | {data['region']} | {data['account']}"
+    text = (
+        f"Project <b>{detail['project-name']}</b> (<a href=\"{logs_url}\">logs</a>)<br />"
+        f"CodeBuild build state <b>{detail['build-status']}</b><br />"
+    )
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "summary": summary,
+        "themeColor": codebuild_build_state_map[detail['build-status']]['color'],
+        "text": text,
+        "title": summary,
+        "potentialAction": []
+    }, codebuild_build_state_map[detail['build-status']]['url']
 
-def handle_codebuild_phase_change(data):
-  detail = data['detail']
-  logs_url = get_logs_url(detail)
-  summary = f"AWS CodeBuild Notification | {data['region']} | {data['account']}"
-  text = (
-    f"Project <b>{detail['project-name']}</b> (<a href=\"{logs_url}\">logs</a>)<br />"
-    f"CodeBuild phase <b>{detail['completed-phase']}</b><br />"
-    f"Codebuild status <b>{detail['completed-phase-status']}</b>"
-  )
-  return {
-      "@type": "MessageCard",
-      "@context": "http://schema.org/extensions",
-      "summary": summary,
-      "themeColor": default_color,
-      "text": text,
-      "title": summary,
-      "potentialAction": []        
-  }
+
+def handle_codebuild_build_phase_change(data):
+    detail = data['detail']
+    logs_url = get_logs_url(detail)
+    summary = f"AWS CodeBuild Notification | {data['region']} | {data['account']}"
+    text = (
+        f"Project <b>{detail['project-name']}</b> (<a href=\"{logs_url}\">logs</a>)<br />"
+        f"CodeBuild phase <b>{detail['completed-phase']}</b><br />"
+        f"Codebuild status <b>{detail['completed-phase-status']}</b>"
+    )
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "summary": summary,
+        "themeColor": codebuild_build_phase_map[detail['completed-phase-status']]['color'],
+        "text": text,
+        "title": summary,
+        "potentialAction": []
+    }, codebuild_build_phase_map[detail['completed-phase-status']]['url']
+
 
 def get_logs_url(detail):
-  return detail.get('additional-information', {}).get('logs',{}).get('deep-link', '#')
+    return detail.get('additional-information', {}).get('logs', {}).get('deep-link', '#')
 
-def handle_codepipeline_state_change(data):
-  detail = data['detail']
-  logs_url = get_logs_url(detail)
-  summary = f"AWS CodePipeline Notification | {data['region']} | {data['account']}"
-  text = (
-    f"Pipeline <b>{detail['pipeline']}</b><br />"
-    f"CodePipeline state <b>{detail['state']}</b><br />"
-  )
-  return {
-      "@type": "MessageCard",
-      "@context": "http://schema.org/extensions",
-      "summary": summary,
-      "themeColor": default_color,
-      "text": text,
-      "title": summary,
-      "potentialAction": []        
-  }
-  
-def handle_codepipeline_execution_state_change(data):
-  detail = data['detail']
-  logs_url = get_logs_url(detail)
-  summary = f"AWS CodePipeline Notification | {data['region']} | {data['account']}"
-  text = (
-    f"Pipeline <b>{detail['pipeline']}</b><br />"
-    f"CodePipeline stage <b>{detail['stage']}</b><br />"
-    f"CodePipeline state <b>{detail['state']}</b>"
-  )
-  return {
-      "@type": "MessageCard",
-      "@context": "http://schema.org/extensions",
-      "summary": summary,
-      "themeColor": default_color,
-      "text": text,
-      "title": summary,
-      "potentialAction": []        
-  }  
+
+def handle_codepipeline_pipeline_execution_state_change(data):
+    detail = data['detail']
+    summary = f"AWS CodePipeline Notification | {data['region']} | {data['account']}"
+    text = (
+        f"Pipeline <b>{detail['pipeline']}</b><br />"
+        f"CodePipeline state <b>{detail['state']}</b><br />"
+    )
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "summary": summary,
+        "themeColor": codepipeline_pipeline_execution_state_map[detail['state']]['color'],
+        "text": text,
+        "title": summary,
+        "potentialAction": []
+    }, codepipeline_pipeline_execution_state_map[detail['state']]['url']
+
+
+def handle_codepipeline_action_execution_state_change(data):
+    detail = data['detail']
+    summary = f"AWS CodePipeline Notification | {data['region']} | {data['account']}"
+    text = (
+        f"Pipeline <b>{detail['pipeline']}</b><br />"
+        f"CodePipeline stage <b>{detail['stage']}</b><br />"
+        f"CodePipeline state <b>{detail['state']}</b>"
+    )
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "summary": summary,
+        "themeColor": codepipeline_action_execution_state_map[detail['state']]['color'],
+        "text": text,
+        "title": summary,
+        "potentialAction": []
+    }, codepipeline_action_execution_state_map[detail['state']]['url']

--- a/sns-teams-relay/template.yaml
+++ b/sns-teams-relay/template.yaml
@@ -5,9 +5,11 @@ Description: Resources to relay SNS messages to a Microsoft Teams webhook.
 
 Metadata:
   Source: https://github.com/CU-CommunityApps/cu-aws-cloudformation/sns-teams-relay/template.yaml
-  Version: "1.0.0"
+  Version: "2.0.0"
   RecommendedStackName: sns-teams-relay-$ENV
   ChangeLog:
+    "2.0.0":
+      - Add support for two different webhook URLs: WEBHOOK_URL_NORMAL, WEBHOOK_URL_ALERT
     "1.0.0":
       - inital release
 
@@ -41,8 +43,12 @@ Parameters:
     Default: https://confluence.cornell.edu/documentation/of/this/deployment
     Type: String
 
-  TeamsWebhookURLParam:
-    Description: URL of documentation about this deployment or these resources
+  TeamsWebhookNormalURLParam:
+    Description: URL for your Teams webhook for success, warning, info messages
+    Type: String
+
+  TeamsWebhookAlertURLParam:
+    Description: URL for your Teams webhook for failure of any type
     Type: String
 
 Mappings: {}
@@ -61,7 +67,8 @@ Resources:
       Description: Relay incoming SNS messages to a Microsoft Teams webhook
       Environment: 
         Variables:
-          WEBHOOK_URL: !Ref TeamsWebhookURLParam
+          WEBHOOK_URL_NORMAL: !Ref TeamsWebhookNormalURLParam
+          WEBHOOK_URL_ALERT: !Ref TeamsWebhookAlertURLParam
       # FileSystemConfigs: 
       #   - FileSystemConfig
       FunctionName: !Sub "sns-teams-relay-${EnvironmentParam}"


### PR DESCRIPTION
### sns-teams-relay v2.0.0
- apply some Python style fixes
- add support for two different webhook URLs; one handles regular notifications, one handles more critical notifications
- add support for contextual colors, depending on notification type